### PR TITLE
Add Node.js Express server and docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,13 @@ services:
       - 8000:8000
     volumes:
       - ./python-server/src:/app/src
+
+  js-server:
+    build:
+      context: ./js-server
+      dockerfile: Dockerfile
+    ports:
+      - 8001:8001
+    volumes:
+      - ./js-server:/app
+    command: yarn start

--- a/js-server/Dockerfile
+++ b/js-server/Dockerfile
@@ -1,0 +1,8 @@
+# Simple Dockerfile for JS Express server
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN yarn install
+COPY . .
+EXPOSE 8001
+CMD ["yarn", "start"]

--- a/js-server/index.js
+++ b/js-server/index.js
@@ -3,6 +3,10 @@ const express = require('express');
 const app = express();
 const PORT = 8001;
 
+app.get('/', (req, res) => {
+  res.send('Hello from Node.js Express server!');
+});
+
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });

--- a/js-server/index.js
+++ b/js-server/index.js
@@ -1,0 +1,8 @@
+// Simple Express server with no endpoints
+const express = require('express');
+const app = express();
+const PORT = 8001;
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/js-server/index.js
+++ b/js-server/index.js
@@ -7,6 +7,6 @@ app.get('/', (req, res) => {
   res.send('Hello from Node.js Express server!');
 });
 
-app.listen(PORT, () => {
+app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server listening on port ${PORT}`);
 });

--- a/js-server/package.json
+++ b/js-server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "js-server",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "nodemon index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.0"
+  }
+}


### PR DESCRIPTION
- Scaffolded a simple JS Express server with nodemon and Dockerfile
- Updated docker-compose.yml to run both Python (FastAPI) and Node.js servers
- Node.js server listens on port 8001, Python server on port 8000
- Both services support live reload for development

Please review the changes.